### PR TITLE
(baby-project-server) Adds github action for publising a artifact

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,12 +5,14 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     container: gradle:6.7-jdk15
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish Build Artifacts
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    container: gradle:6.7-jdk15
+    steps:
+      - name: Get Tag
+        id: data
+        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+      - uses: actions/checkout@v2
+      - name: Run Jar Build
+        run: gradle bootJar
+      - uses: actions/upload-artifact@v2
+        with:
+          name: "baby-project-artifact-${{ steps.data.outputs.SOURCE_TAG }}"
+          path: ${{ github.workspace }}/build
+      - name: Build Finnished
+        run: echo "Artifact Published"


### PR DESCRIPTION
I Relized we can skip having submodules in the deployment repo if each breanch bulishes artifacts and creates release tags. Its good partice in general to do that, this way we just renforce it by making it the only way you can create a deployment