### PR TITLE
(baby-project-server) Changes artifact publish for release publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish Build Artifacts
 
 on:
-  push:
+  create:
     tags:
       - v*
 
@@ -16,9 +16,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run Jar Build
         run: gradle bootJar
-      - uses: actions/upload-artifact@v2
+      - uses: papeloto/action-zip@v1
         with:
-          name: "baby-project-artifact-${{ steps.data.outputs.SOURCE_TAG }}"
-          path: ${{ github.workspace }}/build
-      - name: Build Finnished
-        run: echo "Artifact Published"
+          files: build/
+          dest: baby-project-server-${{ steps.data.outputs.SOURCE_TAG }}.zip
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "baby-project-server-release-${{ steps.data.outputs.SOURCE_TAG }}"
+          files: baby-project-server-${{ steps.data.outputs.SOURCE_TAG }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I removed the publishing the build output as an artifact but instead I it now publishes a new release every time a new tag is created